### PR TITLE
翻译了一些任务的文本

### DIFF
--- a/translations/texts/ai/japaneseruins.aimission.json
+++ b/translations/texts/ai/japaneseruins.aimission.json
@@ -7,7 +7,7 @@
       ]
     },
     "Texts": {
-      "Chs": "据说一座古老的居住着鲛人的山被诅咒了。也许我们应该去调查一下，看看那里到底发生了什么？",
+      "Chs": "据说这座古老的居住着鲛人的山被诅咒了。也许我们应该去调查一下，看看那里到底发生了什么？",
       "Eng": "An ancient mountain populated by hylotl is said to be cursed. Should we go investigate what's going on?"
     }
   },

--- a/translations/texts/ai/japaneseruins.aimission.json
+++ b/translations/texts/ai/japaneseruins.aimission.json
@@ -7,6 +7,7 @@
       ]
     },
     "Texts": {
+      "Chs": "据说一座古老的居住着鲛人的山被诅咒了。也许我们应该去调查一下，看看那里到底发生了什么？",
       "Eng": "An ancient mountain populated by hylotl is said to be cursed. Should we go investigate what's going on?"
     }
   },
@@ -18,6 +19,7 @@
       ]
     },
     "Texts": {
+      "Chs": "巨人山 (8)",
       "Eng": "Mount Gigant (8)"
     }
   },
@@ -29,6 +31,7 @@
       ]
     },
     "Texts": {
+      "Chs": "重新挑战巨人山 (8)",
       "Eng": "Mount Gigant (8) (R)"
     }
   }

--- a/translations/texts/ai/japaneseruins.aimission.json
+++ b/translations/texts/ai/japaneseruins.aimission.json
@@ -7,7 +7,7 @@
       ]
     },
     "Texts": {
-      "Chs": "据说这座古老的居住着鲛人的山被诅咒了。也许我们应该去调查一下，看看那里到底发生了什么？",
+      "Chs": "据说这座居住着鲛人的古老山峰被诅咒了。也许我们应该去调查一下，看看那里到底发生了什么？",
       "Eng": "An ancient mountain populated by hylotl is said to be cursed. Should we go investigate what's going on?"
     }
   },

--- a/translations/texts/ai/precursordungeon.aimission.json
+++ b/translations/texts/ai/precursordungeon.aimission.json
@@ -7,6 +7,7 @@
       ]
     },
     "Texts": {
+      "Chs": "这是一个古老的被遗忘的种族留下的遗迹，里面有非常迷人的科技。",
       "Eng": "Ancient, technologically fantastic ruins of a long-forgotten race."
     }
   },
@@ -18,6 +19,7 @@
       ]
     },
     "Texts": {
+      "Chs": "先驱遗迹 (5)",
       "Eng": "Precursor Ruins(5)"
     }
   },
@@ -29,6 +31,7 @@
       ]
     },
     "Texts": {
+      "Chs": "重新挑战先驱遗迹 (5)",
       "Eng": "Precursor Ruins(5)(R)"
     }
   }

--- a/translations/texts/ai/precursordungeon.aimission.json
+++ b/translations/texts/ai/precursordungeon.aimission.json
@@ -7,7 +7,7 @@
       ]
     },
     "Texts": {
-      "Chs": "这是一个古老的被遗忘的种族留下的遗迹，里面有非常迷人的科技。",
+      "Chs": "这是一个被遗忘的古老种族留下的废墟，里面有非常迷人的科技。",
       "Eng": "Ancient, technologically fantastic ruins of a long-forgotten race."
     }
   },

--- a/translations/texts/ai/precursordungeon.aimission.json
+++ b/translations/texts/ai/precursordungeon.aimission.json
@@ -19,7 +19,7 @@
       ]
     },
     "Texts": {
-      "Chs": "先驱遗迹 (5)",
+      "Chs": "先驱废墟 (5)",
       "Eng": "Precursor Ruins(5)"
     }
   },
@@ -31,7 +31,7 @@
       ]
     },
     "Texts": {
-      "Chs": "重新挑战先驱遗迹 (5)",
+      "Chs": "重新挑战先驱废墟 (5)",
       "Eng": "Precursor Ruins(5)(R)"
     }
   }

--- a/translations/texts/ai/scienceoutpostfu.aimission.json
+++ b/translations/texts/ai/scienceoutpostfu.aimission.json
@@ -20,7 +20,7 @@
       ]
     },
     "Texts": {
-      "Chs": "科学前哨站",
+      "Chs": "访问科学前哨站",
       "Eng": "Visit Science Outpost"
     }
   }

--- a/translations/texts/ai/shoggothmission.aimission.json
+++ b/translations/texts/ai/shoggothmission.aimission.json
@@ -19,7 +19,7 @@
       ]
     },
     "Texts": {
-      "Chs": "^#7fac66;Delta Freya II^reset; (7+)",
+      "Chs": "^#7fac66;永冻废墟^reset; (7+)",
       "Eng": "^#7fac66;Delta Freya II^reset; (7+)"
     }
   },
@@ -31,7 +31,7 @@
       ]
     },
     "Texts": {
-      "Chs": "^#7fac66;重新挑战Delta Freya II^reset; (7+)",
+      "Chs": "^#7fac66;重新挑战永冻废墟^reset; (7+)",
       "Eng": "^#7fac66;Delta Freya II^reset; (7+)(R)"
     }
   }

--- a/translations/texts/ai/snowcrash.aimission.json
+++ b/translations/texts/ai/snowcrash.aimission.json
@@ -7,7 +7,7 @@
       ]
     },
     "Texts": {
-      "Chs": "在一颗遥远行星上，猿族反抗军正在苦恼于人质被科学发展部绑架的事，或许我可以帮助他们。",
+      "Chs": "在一颗遥远行星上，猿族反抗军正在苦恼于被科学发展部绑架的人质的事，或许我可以帮助他们。",
       "Eng": "A band of apex rebels is dealing with a hostage situation with the miniknog on a far-off world. I could go over and try to help them with their problem."
     }
   },

--- a/translations/texts/ai/sunsetriders.aimission.json
+++ b/translations/texts/ai/sunsetriders.aimission.json
@@ -7,7 +7,7 @@
       ]
     },
     "Texts": {
-      "Chs": "新星堡的执法部门正在悬赏一名臭名昭著的罪犯，只要抓住这个罪犯，不论死活，就可以获得一笔相当不错的赏金。或许我可以尝试赚点零花钱。",
+      "Chs": "新星堡的执法部门正在悬赏一名臭名昭著的罪犯，只要抓住这个罪犯，不论死活，都可以获得一笔相当不错的赏金。或许我可以尝试赚点零花钱。",
       "Eng": "Law enforcement at a certain Fort Nova is offering a bounty for a notorious local criminal. I could try my hand at cashing this one in."
     }
   },

--- a/translations/texts/codex/elder/blackbook1k.codex.json
+++ b/translations/texts/codex/elder/blackbook1k.codex.json
@@ -7,6 +7,7 @@
       ]
     },
     "Texts": {
+      "Chs": "污染之源，毒液缠身。\n锁链禁锢，无助哀嚎。\n通路唯一，锁头拾起。\n耐心等待，逐个尝试。\n等待旧日诸神的抉择。",
       "Eng": "Foul liquids, toxic.\nChained and helpless.\nOne, the lock pick.\nBe patient, and judge each in turn.\nAwait the Old Ones decision."
     }
   },

--- a/translations/texts/codex/elder/blackbook1k.codex.json
+++ b/translations/texts/codex/elder/blackbook1k.codex.json
@@ -7,7 +7,7 @@
       ]
     },
     "Texts": {
-      "Chs": "污染之源，毒液缠身。\n锁链禁锢，无助哀嚎。\n通路唯一，锁头拾起。\n耐心等待，逐个尝试。\n等待旧日诸神的抉择。",
+      "Chs": "污染之源，毒液缠身。\n锁链禁锢，无助哀嚎。\n通路唯一，锁头拾起。\n耐心等待，逐个尝试。\n等待旧日诸神的决断。",
       "Eng": "Foul liquids, toxic.\nChained and helpless.\nOne, the lock pick.\nBe patient, and judge each in turn.\nAwait the Old Ones decision."
     }
   },

--- a/translations/texts/codex/elder/blackbook3k.codex.json
+++ b/translations/texts/codex/elder/blackbook3k.codex.json
@@ -19,7 +19,7 @@
       ]
     },
     "Texts": {
-      "Chs": "卫月坠落，\n  回应召唤。\n平衡一切；\n  触发其二，方可通过。",
+      "Chs": "群月坠落，\n  回应召唤。\n平衡一切；\n  触发其二，方可通过。",
       "Eng": "Some moons will fall,\n  answering the Call.\nBalance their mass;\n  by twos shalt thou pass."
     }
   }

--- a/translations/texts/codex/elder/blackbook3k.codex.json
+++ b/translations/texts/codex/elder/blackbook3k.codex.json
@@ -19,7 +19,7 @@
       ]
     },
     "Texts": {
-      "Chs": "群月坠落，\n  回应召唤。\n平衡一切；\n  触发其二，方可通过。",
+      "Chs": "群月坠落，\n  回应召唤。\n平衡质量；\n  触发其二，方可通过。",
       "Eng": "Some moons will fall,\n  answering the Call.\nBalance their mass;\n  by twos shalt thou pass."
     }
   }

--- a/translations/texts/codex/elder/blackbook3k.codex.json
+++ b/translations/texts/codex/elder/blackbook3k.codex.json
@@ -7,6 +7,7 @@
       ]
     },
     "Texts": {
+      "Chs": "完美平衡",
       "Eng": "Perfect Balance"
     }
   },
@@ -18,6 +19,7 @@
       ]
     },
     "Texts": {
+      "Chs": "卫月坠落，\n  回应召唤。\n平衡一切；\n  触发其二，方可通过。",
       "Eng": "Some moons will fall,\n  answering the Call.\nBalance their mass;\n  by twos shalt thou pass."
     }
   }


### PR DESCRIPTION
翻译了两个任务的文本
巨人山 Mount Gigant （8级）
先驱废墟 Precursor Ruins （5级）

翻译了旧日遗迹的任务名
永冻废墟 Delta Freya II （7+级）
（副本名字使用了来自贴吧吧友 @o0建筑学员0o 的攻略贴中的翻译）
（原帖地址：https://tieba.baidu.com/p/5470554536 ）
（PS：这个副本的名字似乎被FU官方改过。原来不叫 Delta Freya II 而是叫 Frozen Wastes）

翻译了旧日遗迹中的的两本书籍 
《道途》（_Passage_）
《完美平衡》（_Perfect Balance_）
文本其实就是从贴吧吧友 @o0建筑学员0o 的攻略帖中抄的啦。。。（有一点点的改动）